### PR TITLE
Max image size can now be set within the web.config (optional)

### DIFF
--- a/Tinifier.Core/Services/TinyPNG/TinyPNGConnectorService.cs
+++ b/Tinifier.Core/Services/TinyPNG/TinyPNGConnectorService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Text;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -77,7 +78,15 @@ namespace Tinifier.Core.Services.TinyPNG
         private async Task<TinyResponse> TinifyByteArrayAsync(byte[] imageByteArray)
         {
             TinyResponse tinyResponse;
-            if(imageByteArray.Length > PackageConstants.MaxImageSize)
+
+            var maxImageSize = 0;
+
+            if (!int.TryParse(ConfigurationManager.AppSettings["Tinifier.MaxImageSize"], out maxImageSize) || maxImageSize == 0)
+            {
+                maxImageSize = PackageConstants.MaxImageSize;
+            }
+
+            if (imageByteArray.Length > maxImageSize)
             {
                 tinyResponse = new TinyResponse
                 {

--- a/Tinifier/Web.config
+++ b/Tinifier/Web.config
@@ -53,6 +53,9 @@
     <add key="owin:appStartup" value="UmbracoDefaultOwinStartup" />
     <add key="Umbraco.ModelsBuilder.Enable" value="true" />
     <add key="Umbraco.ModelsBuilder.ModelsMode" value="PureLive" />
+
+    <!--This is optional, will default to 14000000 if it is not included-->
+    <add key="Tinifier.MaxImageSize" value="30000000"/>
   </appSettings>
   <connectionStrings>
     <remove name="umbracoDbDSN" />


### PR DESCRIPTION
I have added an optional web.config setting "Tinifier.MaxImageSize"

If this value is set, then it will override the MaxImageSize const in the PackagesConstants class.