### PR TITLE
Change xpath to identify correct nodes

### DIFF
--- a/Tinifier.Core/Services/BlobStorage/AzureBlobStorageService.cs
+++ b/Tinifier.Core/Services/BlobStorage/AzureBlobStorageService.cs
@@ -19,11 +19,11 @@ namespace Tinifier.Core.Services.BlobStorage
             var path = HostingEnvironment.MapPath("~/config/FileSystemProviders.config");
             var doc = new XmlDocument();
             doc.Load(path);
-            var node = doc.SelectSingleNode("//Provider");
+            var node = doc.SelectSingleNode("//Provider[@alias='media']");
 
             if (node != null)
             {
-                var keysNodes = node.LastChild.SelectNodes("//add");
+                var keysNodes = node.LastChild.SelectNodes("descendant::add");
                 var dictionary = new Dictionary<string, string>();
 
                 foreach (XmlNode xmlNode in keysNodes)


### PR DESCRIPTION
When using Tinifier 1.6.0 with Azure blob storage and multiple providers AzureBlobStorageService throws an argument exception "An item with the same key has already been added."

This was happening because the XPath expression `node.LastChild.SelectNodes("//add");` selects all nodes in the document, not just the children of "node". This PR fixes that by using the "descendant" axis.

 